### PR TITLE
Add/Update Job form adjustments

### DIFF
--- a/opportunities/forms.py
+++ b/opportunities/forms.py
@@ -11,7 +11,6 @@ class AddJobForm(ModelForm):
     class Meta:
         # specify model to be used
         model = Job
-        
         # specify fields to be used
         fields = [
             "author",
@@ -23,6 +22,8 @@ class AddJobForm(ModelForm):
             "application_status",
             "skills"
         ]
+        # widgets
+        widgets = {"author": forms.HiddenInput()}
     skills = forms.ModelMultipleChoiceField(
         queryset=Skills.objects.all(),
         widget=forms.CheckboxSelectMultiple

--- a/opportunities/forms.py
+++ b/opportunities/forms.py
@@ -21,6 +21,7 @@ class AddJobForm(ModelForm):
             "salary",
             "description",
             "application_status",
+            "skills"
         ]
 
 

--- a/opportunities/forms.py
+++ b/opportunities/forms.py
@@ -11,7 +11,7 @@ class AddJobForm(ModelForm):
     class Meta:
         # specify model to be used
         model = Job
-
+        
         # specify fields to be used
         fields = [
             "author",
@@ -23,6 +23,10 @@ class AddJobForm(ModelForm):
             "application_status",
             "skills"
         ]
+    skills = forms.ModelMultipleChoiceField(
+        queryset=Skills.objects.all(),
+        widget=forms.CheckboxSelectMultiple
+    )
 
 
 class AddSkillForm(forms.ModelForm):

--- a/opportunities/models.py
+++ b/opportunities/models.py
@@ -2,6 +2,20 @@ from django.db import models
 from django.contrib.auth.models import User
 from django.db.models.deletion import CASCADE
 
+# Constants
+EMPLOYMENT_CHOICES = (
+    ("Full-Time", "Full-Time"),
+    ("Part-Time", "Part-Time"),
+    ("Internship", "Internship"),
+)
+
+APPLICATION_STATUS_CHOICES = (
+    ("Applied", "Applied"),
+    ("Interviewing", "Interviewing"),
+    ("Rejected", "Rejected"),
+    ("Received Offer", "Received Offer"),
+)
+
 
 class Skills(models.Model):
     name = models.CharField(max_length=100)
@@ -15,10 +29,10 @@ class Job(models.Model):
     author = models.ForeignKey(User, on_delete=CASCADE)
     company = models.CharField(max_length=255)
     title = models.CharField(max_length=255)
-    employment_type = models.CharField(max_length=255)
+    employment_type = models.CharField(max_length=255, choices=EMPLOYMENT_CHOICES)
     salary = models.IntegerField(default=0)
     description = models.TextField()
-    application_status = models.CharField(max_length=128)
+    application_status = models.CharField(max_length=128, choices=APPLICATION_STATUS_CHOICES)
     application_date = models.DateTimeField(auto_now_add=True)
     last_modified = models.DateTimeField(auto_now=True)
 

--- a/opportunities/templates/opportunities/jobs.j2
+++ b/opportunities/templates/opportunities/jobs.j2
@@ -60,6 +60,7 @@
                             <th>Employment Type</th>
                             <th>Salary</th>
                             <th>Description</th>
+                            <th>Skills</th>
                             <th>Application Status</th>
                             <th>Application Date</th>
                             <th colspan="2"></th>
@@ -73,6 +74,11 @@
                             <td>{{ job.employment_type }}</td>
                             <td>{{ job.salary }}</td>
                             <td>{{ job.description }}</td>
+                            <td>
+                                {% for skill in job.skills.all %}
+                                    {{skill}}
+                                {% endfor %}
+                            </td>
                             <td>{{ job.application_status }}</td>
                             <td>{{job.application_date|date:'Y-m-d'}}</td>
                             {# Update job #}

--- a/opportunities/views.py
+++ b/opportunities/views.py
@@ -48,7 +48,10 @@ def about(request):
 @login_required
 def jobs(request):
     """Renders the Jobs page"""
-    context = {"jobs": Job.objects.filter(author=request.user).all()}
+    job = Job.objects.filter(author=request.user).all()
+    context = {
+        "jobs": job
+    }
 
     # add job form
     form = AddJobForm(request.POST or None, initial={"author": request.user})

--- a/opportunities/views.py
+++ b/opportunities/views.py
@@ -48,9 +48,8 @@ def about(request):
 @login_required
 def jobs(request):
     """Renders the Jobs page"""
-    job = Job.objects.filter(author=request.user).all()
     context = {
-        "jobs": job
+        "jobs": Job.objects.filter(author=request.user).all()
     }
 
     # add job form


### PR DESCRIPTION
- Hide "author" field of form so logged in user can only add job postings for their own account
- Limit the string options of "employment_type" and "application_status"
- Implement a checkbox multiple select for Skills instead of dropdown Select